### PR TITLE
feat: Global Component Discovery System

### DIFF
--- a/app/Services/GlobalComponentDiscovery.php
+++ b/app/Services/GlobalComponentDiscovery.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Collection;
+
+class GlobalComponentDiscovery
+{
+    private array $searchPaths = [];
+    
+    public function __construct()
+    {
+        $home = getenv('HOME');
+        $this->searchPaths = [
+            $home . '/.composer/vendor/*/*/conduit.json',
+            $home . '/.config/composer/vendor/*/*/conduit.json',
+        ];
+    }
+    
+    public function discover(): Collection
+    {
+        $components = collect();
+        
+        foreach ($this->searchPaths as $pattern) {
+            $manifests = glob($pattern);
+            
+            if (!$manifests) {
+                continue;
+            }
+            
+            foreach ($manifests as $manifestPath) {
+                try {
+                    $manifest = json_decode(file_get_contents($manifestPath), true);
+                    
+                    if (!$manifest || !isset($manifest['name'])) {
+                        continue;
+                    }
+                    
+                    // Extract package info from path
+                    preg_match('|vendor/([^/]+)/([^/]+)/conduit\.json$|', $manifestPath, $matches);
+                    $vendor = $matches[1] ?? 'unknown';
+                    $package = $matches[2] ?? 'unknown';
+                    
+                    // Get providers from manifest or try to detect from composer.json
+                    $providers = $manifest['providers'] ?? [];
+                    
+                    if (empty($providers)) {
+                        // Try to get from composer.json Laravel extra section
+                        $composerPath = dirname($manifestPath) . '/composer.json';
+                        if (file_exists($composerPath)) {
+                            $composer = json_decode(file_get_contents($composerPath), true);
+                            $providers = $composer['extra']['laravel']['providers'] ?? [];
+                        }
+                    }
+                    
+                    $components->push([
+                        'name' => $manifest['name'],
+                        'package' => "$vendor/$package",
+                        'description' => $manifest['description'] ?? '',
+                        'version' => $manifest['version'] ?? 'unknown',
+                        'path' => dirname($manifestPath),
+                        'global' => true,
+                        'providers' => $providers,
+                    ]);
+                } catch (\Exception $e) {
+                    continue;
+                }
+            }
+        }
+        
+        return $components;
+    }
+    
+    public function loadComponent(array $component): void
+    {
+        $componentPath = $component['path'];
+        
+        // Load component's autoloader if it exists
+        $autoloadPath = $componentPath . '/vendor/autoload.php';
+        if (file_exists($autoloadPath)) {
+            require_once $autoloadPath;
+        }
+        
+        // Register service providers
+        foreach ($component['providers'] as $provider) {
+            if (class_exists($provider)) {
+                app()->register($provider);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🌍 Global Component Discovery

This PR introduces a global component discovery system that enables Conduit to automatically find and load components installed via Composer's global directory.

## 🎯 Problem Solved

Currently, components must be installed locally into Conduit's vendor directory, which:
- Pollutes Conduit's composer.json with user-specific components
- Makes it difficult to maintain a clean Conduit installation
- Prevents users from having their personal component toolkit

## ✨ Solution

This PR adds automatic discovery of globally installed Conduit components, allowing users to:

```bash
composer global require jordanpartridge/conduit-spotify
composer global require someone/conduit-docker
# Components are automatically available in Conduit\!
```

## 🔧 Implementation Details

### GlobalComponentDiscovery Service
- Scans common global Composer paths:
  - `~/.composer/vendor/*/*/conduit.json`
  - `~/.config/composer/vendor/*/*/conduit.json`
- Extracts component metadata from conduit.json
- Falls back to composer.json for Laravel service providers
- Loads component autoloader and registers providers

### Integration
- Added to AppServiceProvider boot process
- Graceful failure handling (won't break Conduit if no components found)
- Verbose mode logging for debugging

## ✅ Testing

Tested with `jordanpartridge/conduit-env-manager`:
1. Installed globally: `composer global require jordanpartridge/conduit-env-manager`
2. Ran local Conduit: `php conduit list`
3. Commands appeared: `env:init`, `env:get`, `env:set`, `env:backup`

## 🚀 Future Enhancements

This lays the foundation for:
- `conduit components install spotify --global` flag
- Global component management commands
- User-specific component toolkits
- Clean separation of core and user components

## 📊 Impact

- **No breaking changes** - purely additive
- **No performance impact** - discovery only happens on boot
- **No configuration needed** - works out of the box

## 🧪 How to Test

1. Check out this branch
2. Install a component globally: `composer global require jordanpartridge/conduit-env-manager`
3. Run: `php conduit list | grep env:`
4. See env commands available\!

This is the first step toward the modular component architecture discussed in the VISION.md\!