### PR TITLE
Fix: Add missing logging configuration

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -1,0 +1,43 @@
+<?php
+
+return [
+    'default' => env('LOG_CHANNEL', 'single'),
+
+    'deprecations' => [
+        'channel' => env('LOG_DEPRECATIONS_CHANNEL', 'null'),
+        'trace' => env('LOG_DEPRECATIONS_TRACE', false),
+    ],
+
+    'channels' => [
+        'single' => [
+            'driver' => 'single',
+            'path' => env('CONDUIT_STORAGE_PATH', storage_path()).'/logs/conduit.log',
+            'level' => env('LOG_LEVEL', 'debug'),
+            'replace_placeholders' => true,
+        ],
+
+        'daily' => [
+            'driver' => 'daily',
+            'path' => env('CONDUIT_STORAGE_PATH', storage_path()).'/logs/conduit.log',
+            'level' => env('LOG_LEVEL', 'debug'),
+            'days' => env('LOG_DAILY_DAYS', 14),
+            'replace_placeholders' => true,
+        ],
+
+        'null' => [
+            'driver' => 'monolog',
+            'handler' => \Monolog\Handler\NullHandler::class,
+        ],
+
+        'emergency' => [
+            'path' => env('CONDUIT_STORAGE_PATH', storage_path()).'/logs/conduit.log',
+        ],
+
+        'deprecations' => [
+            'driver' => 'single',
+            'path' => env('CONDUIT_STORAGE_PATH', storage_path()).'/logs/deprecations.log',
+            'level' => env('LOG_LEVEL', 'info'),
+            'replace_placeholders' => true,
+        ],
+    ],
+];


### PR DESCRIPTION
## Summary
- Fixes 'Call to undefined method Psr\Log\NullLogger::channel()' error
- Adds proper logging.php configuration file

## Problem
When running Conduit commands like `conduit spotify:play`, users encounter:
```
Error: Call to undefined method Psr\Log\NullLogger::channel()
```

This happens because Laravel's exception handler expects a logger with a `channel()` method but receives `NullLogger` when no logging configuration exists.

## Solution
Added a proper `logging.php` configuration file with:
- Default single file logging channel
- Null channel for suppressing deprecations  
- Daily rotation option
- Emergency logging support
- Proper storage path handling for global installations

## Test Plan
1. Install Conduit globally via Composer
2. Run `conduit spotify:play` or any other command
3. Verify no NullLogger errors occur