### PR TITLE
fix(sync): remove non-existent ComponentManager dependency

### DIFF
--- a/app/Commands/System/SyncComponentsCommand.php
+++ b/app/Commands/System/SyncComponentsCommand.php
@@ -2,7 +2,6 @@
 
 namespace App\Commands\System;
 
-use App\Services\ComponentManager;
 use App\Services\JsonComponentRegistrar;
 use App\Services\ServiceProviderDetector;
 use Illuminate\Console\Command;
@@ -16,7 +15,6 @@ class SyncComponentsCommand extends Command
     protected $description = 'Sync component registry with installed packages (post-install hook)';
 
     public function handle(
-        ComponentManager $componentManager,
         JsonComponentRegistrar $registrar,
         ServiceProviderDetector $detector
     ): int {


### PR DESCRIPTION
## Summary
Fixes issue #95 by removing the non-existent ComponentManager class dependency from SyncComponentsCommand.php. The sync-components command was failing with a fatal error because it attempted to inject a class that doesn't exist in the codebase.

## Changes
- Removed the unused `use App\Services\ComponentManager;` import statement
- Removed the `ComponentManager $componentManager` parameter from the `handle()` method
- The command now only uses `JsonComponentRegistrar` and `ServiceProviderDetector` which are the actual required dependencies

## Why This Fix
The SyncComponentsCommand was attempting to inject ComponentManager on line 19, but this class does not exist in the codebase. This caused the command to fail at runtime with a service container resolution error.

## Related Issues
Closes #95

## Testing
- [ ] Run `php artisan sync-components` to verify the command executes without errors
- [ ] Confirm component registry is properly synchronized
- [ ] No functional changes to the command output (only removed unused dependency)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal component synchronization command structure for improved code organization and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->